### PR TITLE
Work around system service reload bug in DSM 6.2.2-24922 Update 4

### DIFF
--- a/reload-certs.sh
+++ b/reload-certs.sh
@@ -29,6 +29,12 @@ for domain_id in $(jq -r 'keys[]' $INFO); do
       for f in cert.pem chain.pem fullchain.pem privkey.pem; do
         cat $src_path/$f > $crtpath/$f
       done
+      ## Work around bug in DSM 6.2.2-24922 Update 4 for system
+      if [ "$subscriber" = "system" -a "$service" = "default" ]; then
+        if fgrep '[ "$1" = "default" ] && exit' $reload >/dev/null; then
+          service="default-bug-workaround"
+        fi
+      fi
       echo "  reloading..."
       $reload $service > /dev/null
     fi


### PR DESCRIPTION
Work around bug in /usr/libexec/certificate.d/system which exits if service "default" is specified, by changing the service that is specified. On my NASes with DSM 6.2.2-24922 U4 installed, `/usr/libexec/certificate.d/system` looks like this:
```
#!/bin/bash

[ "$1" = "default" ] && exit

/usr/syno/sbin/synoservice --reload nginx
```
So the service reload script in fact does _not_ reload nginx if service `default` is specified, which based on the contents of INFO is what the script does on my NASes.